### PR TITLE
Create 'init' command

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+defaults/

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
+const _ = require('underscore');
 const hubtasks = require('./hubtasks');
+const init = require('./init');
 const program = require('commander');
 
 program
@@ -8,6 +10,17 @@ program
   .option('--tasks', 'List available tasks')
   .action((tasks, cmd) => {
     hubtasks.runTasks(tasks, cmd.tasks);
+  });
+
+program
+  .command('init')
+  .option('--config', 'Initializes config files')
+  .option('--designs', 'Initializes an example designs directory')
+  .option('--context', 'Initializes an example context directory')
+  .option('--all', 'Initializes config, designs, and context (same as omitting the flag altogether)')
+  .action(cmd => {
+    const options = _.pick(cmd, 'config', 'designs', 'context', 'all');
+    init.run(options);
   });
 
 program.parse(process.argv);

--- a/bin/init.js
+++ b/bin/init.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+const _ = require('underscore');
+const packageJson = require('../package.json');
+const shell = require('shelljs');
+
+const DOWNLOAD_URL_BASE = packageJson.repository + "/trunk/defaults/";
+
+function downloadFromGit(path) {
+  shell.exec("svn export " + DOWNLOAD_URL_BASE + path);
+}
+
+function initConfigs() {
+  console.log("Initializing config files");
+  downloadFromGit("cli-config.yaml");
+  downloadFromGit("server-config.yaml");
+  console.log("Done initializing config files");
+}
+
+function initDesigns() {
+  console.log('Initializing designs directory');
+  downloadFromGit("designs");
+  console.log('Done initializing designs directory');
+}
+
+function initContext() {
+  console.log('Initializing context directory');
+  downloadFromGit("context");
+  console.log('Done initializing context directory');
+}
+
+function run(args) {
+  if (_.size(args) === 0 || args.all) {
+    args = {
+      config: true,
+      designs: true,
+      context: true
+    };
+  }
+
+  if (args.config) {
+    initConfigs();
+  }
+
+  if (args.designs) {
+    initDesigns();
+  }
+
+  if (args.context) {
+    initContext();
+  }
+}
+
+module.exports = {
+  run
+};


### PR DESCRIPTION
Adds `hs init` for creating local configs/example templates/content.

Used like so:
```
yarn hs init    # inits everything
yarn hs init --config   # inits server-config and cli-config
yarn hs init --designs   # inits example templates
yarn hs init --context    # inits dummy entities
```