### PR TITLE
Add portalId to server-config.yaml

### DIFF
--- a/defaults/server-config.yaml
+++ b/defaults/server-config.yaml
@@ -6,6 +6,8 @@
 #|_|  |_|\__,_|_.__/|______| |_____/ \___|_|    \_/ \___|_|   
 #
 
+portalId: 123
+
 # base directory to load context settings from, defaults to current dir
 contextBaseDir: context
 


### PR DESCRIPTION
Portal ID is now configured here instead of in `site-settings.json`