### PR TITLE
Fix init command

### DIFF
--- a/bin/init.js
+++ b/bin/init.js
@@ -7,7 +7,7 @@ const shell = require('shelljs');
 const DOWNLOAD_URL_BASE = packageJson.repository + "/trunk/defaults/";
 
 function downloadFromGit(path) {
-  shell.exec("svn export " + DOWNLOAD_URL_BASE + path);
+  shell.exec("svn export --trust-server-cert --non-interactive " + DOWNLOAD_URL_BASE + path);
 }
 
 function initConfigs() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/local-cms-server-cli",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "description": "CLI tools to be paired with @hubspot/local-cms-server",
   "main": "gulpfile.js",
   "scripts": {


### PR DESCRIPTION
Addresses some svn errors that may pop up complaining about certificates. This is just a temporary fix, as we probably shouldn't use svn in the long term