### PR TITLE
Add some defaults to cli-config.yaml

### DIFF
--- a/defaults/cli-config.yaml
+++ b/defaults/cli-config.yaml
@@ -1,6 +1,6 @@
 # common args used by multiple gulp tasks
 hapikey: &hk null
-contextDirPath: &contextPath null
+contextDirPath: &contextPath context
 
 download-blogs:
   hapikey: *hk
@@ -24,7 +24,7 @@ download-designs:
   username: null
   password: null
   portalId: null
-  outDir: null
+  outDir: designs
 
 download-hubdb:
   hapikey: *hk


### PR DESCRIPTION
Adds default values for the `designs/` and `context/` directories, to match the defaults in `server-config.yaml`