### PR TITLE
Replace svn export with shell.cp

### DIFF
--- a/bin/init.js
+++ b/bin/init.js
@@ -4,28 +4,29 @@ const _ = require('underscore');
 const packageJson = require('../package.json');
 const shell = require('shelljs');
 
-const DOWNLOAD_URL_BASE = packageJson.repository + "/trunk/defaults/";
+const projectRoot = process.cwd();
+const scriptRoot = __dirname;
 
-function downloadFromGit(path) {
-  shell.exec("svn export --trust-server-cert --non-interactive " + DOWNLOAD_URL_BASE + path);
+function copyFromPackage(fileName) {
+  shell.cp("-R", `${scriptRoot}/../defaults/${fileName}`, projectRoot);
 }
 
 function initConfigs() {
   console.log("Initializing config files");
-  downloadFromGit("cli-config.yaml");
-  downloadFromGit("server-config.yaml");
+  copyFromPackage("cli-config.yaml");
+  copyFromPackage("server-config.yaml");
   console.log("Done initializing config files");
 }
 
 function initDesigns() {
   console.log('Initializing designs directory');
-  downloadFromGit("designs");
+  copyFromPackage("designs");
   console.log('Done initializing designs directory');
 }
 
 function initContext() {
   console.log('Initializing context directory');
-  downloadFromGit("context");
+  copyFromPackage("context");
   console.log('Done initializing context directory');
 }
 

--- a/bin/init.js
+++ b/bin/init.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 const _ = require('underscore');
-const packageJson = require('../package.json');
 const shell = require('shelljs');
 
 const projectRoot = process.cwd();

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "hs-cms-server": "./bin/cli.js"
   },
   "files": [
-    "bin"
+    "bin",
+    "default"
   ],
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
Includes the contents of the `default/` directory in the npm package, and then does a `cp` do initialize the relevant files/directories rather than `svn export`