### PR TITLE
Trigger browser open

### DIFF
--- a/bin/main.js
+++ b/bin/main.js
@@ -1,11 +1,14 @@
 #!/usr/bin/env node
 
 const fs = require('fs');
+const opn = require('opn');
+const retry = require('requestretry');
 const shell = require('shelljs');
 const yaml = require('js-yaml');
 
 const CONFIG_FILE = 'server-config.yaml';
 const cwd = process.cwd();
+const URL = "http://localhost:8080";
 
 function run() {
   if (!fs.existsSync(`${process.cwd()}/${CONFIG_FILE}`)) {
@@ -26,7 +29,23 @@ function run() {
   `;
 
   console.log("Running: " + cmd);
-  shell.exec(cmd);
+  shell.exec(cmd, { async: true } );
+  openBrowser();
+}
+
+function openBrowser() {
+  retry({
+    url: URL,
+    json: true,
+    maxAttempts: 100,
+    retryDelay: 1000
+  })
+  .then(() => {
+    opn(URL);
+  })
+  .catch(() => {
+    console.log(`Unable to open browser. Try manually navigating to ${URL}`);
+  });
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -27,9 +27,11 @@
     "js-yaml": "^3.12.1",
     "knex": "^0.16.3",
     "minimist": "^1.2.0",
+    "opn": "^5.4.0",
     "promise": "^8.0.2",
     "request": "^2.88.0",
     "request-promise": "^4.2.2",
+    "requestretry": "^3.1.0",
     "shelljs": "^0.8.3",
     "sqlite3": "^4.0.6",
     "underscore": "^1.9.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1178,7 +1178,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.0, extend@~3.0.2:
+extend@^3.0.0, extend@^3.0.2, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -1967,6 +1967,11 @@ is-windows@^1.0.1, is-windows@^1.0.2:
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
 
+is-wsl@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
+  integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
+
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
@@ -2590,6 +2595,13 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+opn@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/opn/-/opn-5.4.0.tgz#cb545e7aab78562beb11aa3bfabc7042e1761035"
+  integrity sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==
+  dependencies:
+    is-wsl "^1.1.0"
+
 optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
@@ -3067,6 +3079,15 @@ request@^2.87.0, request@^2.88.0:
     tough-cookie "~2.4.3"
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
+
+requestretry@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/requestretry/-/requestretry-3.1.0.tgz#c8e1976bb946f14889d3604bbad56a01d191c10d"
+  integrity sha512-DkvCPK6qvwxIuVA5TRCvi626WHC2rWjF/n7SCQvVHAr2JX9i1/cmIpSEZlmHAo+c1bj9rjaKoZ9IsKwCpTkoXA==
+  dependencies:
+    extend "^3.0.2"
+    lodash "^4.17.10"
+    when "^3.7.7"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -3845,6 +3866,11 @@ vinyl@^2.0.0:
     cloneable-readable "^1.0.0"
     remove-trailing-separator "^1.0.1"
     replace-ext "^1.0.0"
+
+when@^3.7.7:
+  version "3.7.8"
+  resolved "https://registry.yarnpkg.com/when/-/when-3.7.8.tgz#c7130b6a7ea04693e842cdc9e7a1f2aa39a39f82"
+  integrity sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I=
 
 which-module@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
After moving the hubl server to docker, the java code for automatically opening the browser stopped working, since that's not something that is available inside the docker container.

This PR moves that logic to the node `main.js` script, and just keeps pinging `http://localhost:8080` until it gets a 200 response, and then uses an npm package to open the user's default browser.