### PR TITLE
Add prompts during init task

### DIFF
--- a/bin/init.js
+++ b/bin/init.js
@@ -1,20 +1,62 @@
 #!/usr/bin/env node
 
 const _ = require('underscore');
+const fs = require('fs');
+const inquirer = require('inquirer');
 const shell = require('shelljs');
+const yaml = require('js-yaml');
 
 const projectRoot = process.cwd();
 const scriptRoot = __dirname;
+
+const CLI_CONF_FILENAME = 'cli-config.yaml';
+const SERVER_CONF_FILENAME = 'server-config.yaml';
+const CONFIG_QUESTIONS = [
+  {
+    type: 'input',
+    name: 'hapikey',
+    message: 'Enter hapikey (default null)',
+  },
+  {
+    type: 'input',
+    name: 'portalId',
+    message: 'Enter portalId (default 123)',
+  },
+  {
+    type: 'input',
+    name: 'username',
+    message: 'Enter FTP username (default null)',
+  },
+  {
+    type: 'password',
+    name: 'password',
+    message: 'Enter FTP password (default null)',
+  }
+];
 
 function copyFromPackage(fileName) {
   shell.cp("-R", `${scriptRoot}/../defaults/${fileName}`, projectRoot);
 }
 
 function initConfigs() {
-  console.log("Initializing config files");
-  copyFromPackage("cli-config.yaml");
-  copyFromPackage("server-config.yaml");
-  console.log("Done initializing config files");
+  inquirer
+    .prompt(CONFIG_QUESTIONS)
+    .then(answers => {
+      console.log("Initializing config files");
+      copyFromPackage("cli-config.yaml");
+      copyFromPackage("server-config.yaml");
+
+      const cliConf = yaml.safeLoad(fs.readFileSync(`${projectRoot}/${CLI_CONF_FILENAME}`, 'utf8'));
+      const serverConf = yaml.safeLoad(fs.readFileSync(`${projectRoot}/${SERVER_CONF_FILENAME}`, 'utf8'));
+      if (answers.hapikey) cliConf.hapikey = answers.hapikey;
+      if (answers.portalId) cliConf.portalId = answers.portalId;
+      if (answers.username) cliConf.username = answers.username;
+      if (answers.password) cliConf.password = answers.password;
+      if (answers.portalId) serverConf.portalId = answers.portalId;
+      fs.writeFileSync(`./${CLI_CONF_FILENAME}`, yaml.safeDump(cliConf));
+      fs.writeFileSync(`./${SERVER_CONF_FILENAME}`, yaml.safeDump(serverConf));
+      console.log("Done initializing config files");
+    });
 }
 
 function initDesigns() {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint-plugin-node": "^8.0.0",
     "gulp": "^4.0.0",
     "gulplog": "^1.0.0",
+    "inquirer": "^6.2.2",
     "js-yaml": "^3.12.1",
     "knex": "^0.16.3",
     "minimist": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2113,7 +2113,7 @@ ini@^1.3.4, ini@~1.3.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
 
-inquirer@^6.1.0:
+inquirer@^6.1.0, inquirer@^6.2.2:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.2.tgz#46941176f65c9eb20804627149b743a218f25406"
   integrity sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==


### PR DESCRIPTION
When running `yarn hs-cms-server init`, it will now prompt the user for hapikey, portalId, and ftp creds so they don't have to go into their configs after the fact and add this information