### PR TITLE
Add FTP upload command

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -5,6 +5,7 @@ const hubtasks = require('./hubtasks');
 const init = require('./init');
 const program = require('commander');
 const server = require('./main.js');
+const FtpUploadTask = require('./ftp_upload').FtpUploadTask;
 
 program
   .command('run-tasks [tasks...]')
@@ -28,6 +29,12 @@ program
   .command('start')
   .action(() => {
     server.run();
+  });
+
+program
+  .command('upload')
+  .action(async () => {
+    await new FtpUploadTask().run();
   });
 
 program.parse(process.argv);

--- a/bin/ftp_upload.js
+++ b/bin/ftp_upload.js
@@ -1,0 +1,87 @@
+const _ = require('underscore');
+const BaseTask = require('./tasks/base_task').BaseTask;
+const CONSTANTS = require('./tasks/constants');
+const Ftp = require('easy-ftp');
+const inquirer = require('inquirer');
+
+const taskName = 'ftp-upload';
+
+class FtpUploadTask extends BaseTask {
+  constructor() {
+    const requiredArgs = ['username', 'password', 'designsPath', 'portalId', 'files'];
+    super(taskName, requiredArgs);
+  }
+
+  static getTaskName() {
+    return taskName;
+  }
+
+  async run() {
+    const args = this.args;
+    const designsPath = args[taskName].designsPath;
+    const files = _.filter(args[taskName].files, file => file !== null);
+    if (_.size(files) === 0) {
+      console.log('No files to upload. Add them to the ftp-upload config in cli-config.yaml');
+      return;
+    }
+    const ftpPrefix = `portals/${args.portalId}/content/designs`;
+    let uploads = _.map(files, file => {
+      return {
+        local: `${designsPath}/${file}`,
+        remote: `${ftpPrefix}/${file}`
+      };
+    });
+    const confirmed = await this.confirmUpload(uploads);
+    if (!confirmed) return;
+
+    console.log('Starting FTP upload...');
+    const config = {
+      host: CONSTANTS.FTP_HOST,
+      username: args.username,
+      password: args.password,
+      secure: true,
+      port: 3200
+    };
+    const client = new Ftp();
+    client.connect(config);
+    try {
+      await this.uploadToFtp(client, uploads);
+    } catch (err) {
+      console.log('Error uploading to FTP: ', err);
+    } finally {
+      client.close();
+    }
+
+    console.log('Finished with FTP upload.');
+  }
+
+  confirmUpload(uploads) {
+    let uploadStr = '\nLocal File --> FTP Destination\n\n';
+    uploads.forEach(upload => {
+      uploadStr += `${upload.local} --> ${upload.remote}\n`;
+    });
+    console.log(uploadStr);
+    return inquirer
+      .prompt([{
+        type: 'confirm',
+        name: 'confirmed',
+        message: 'Does this look ok?',
+        default: true,
+      }])
+      .then(answer => answer.confirmed);
+  }
+
+  uploadToFtp(client, uploads) {
+    return new Promise((resolve, reject) => {
+      client.upload(uploads, err => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+}
+
+module.exports = { FtpUploadTask }

--- a/defaults/cli-config.yaml
+++ b/defaults/cli-config.yaml
@@ -29,3 +29,8 @@ download-menus:
 
 download-resource-mappings:
   limit: null
+
+ftp-upload:
+  designsPath: designs
+  files:
+    - null

--- a/tests/ftp_upload.test.js
+++ b/tests/ftp_upload.test.js
@@ -1,0 +1,32 @@
+const FtpUploadTask = require('../bin/ftp_upload').FtpUploadTask;
+const testBase = require('./tasks/test_base');
+
+const taskName = FtpUploadTask.getTaskName();
+
+it('Should not throw an error if the required args are present.', () => {
+  const config = {
+    portalId: 123,
+    username: 'user',
+    password: 'password',
+    [taskName]: {
+      designsPath: 'designs',
+      files: [ 'test.txt' ] 
+    }
+  };
+  testBase.setupMocks(config);
+  new FtpUploadTask();
+});
+
+it('Should throw an error if the required args are absent.', () => {
+  const config = {
+    portalId: null,
+    username: null,
+    password: null,
+    [taskName]: {
+      designsPath: null,
+      files: null
+    }
+  };
+  testBase.setupMocks(config);
+  expect(() => new FtpUploadTask()).toThrow();
+});

--- a/tests/tasks/download_ftp_designs.test.js
+++ b/tests/tasks/download_ftp_designs.test.js
@@ -1,0 +1,30 @@
+const DesignsFtpTask = require('../../bin/tasks/download_ftp_designs').DesignsFtpTask;
+const testBase = require('./test_base');
+
+const taskName = DesignsFtpTask.getTaskName();
+
+it('Should not throw an error if the required args are present.', () => {
+  const config = {
+    username: 'user',
+    password: 'password',
+    portalId: 123,
+    [taskName]: {
+      outDir: 'designs'
+    }
+  };
+  testBase.setupMocks(config);
+  new DesignsFtpTask();
+});
+
+it('Should throw an error if the required args are absent.', () => {
+  const config = {
+    username: null,
+    password: null,
+    portalId: null,
+    [taskName]: {
+      outDir: null
+    }
+  };
+  testBase.setupMocks(config);
+  expect(() => new DesignsFtpTask()).toThrow();
+});

--- a/tests/tasks/hubdb_download.test.js
+++ b/tests/tasks/hubdb_download.test.js
@@ -1,0 +1,28 @@
+const HubDbTask = require('../../bin/tasks/hubdb_download').HubDbTask;
+const testBase = require('./test_base');
+
+const taskName = HubDbTask.getTaskName();
+
+it('Should not throw an error if the required args are present.', () => {
+  const config = {
+    hapikey: 12345,
+    pathToContextDir: 'context',
+    [taskName]: {
+      batchSize: 1
+    }
+  };
+  testBase.setupMocks(config);
+  new HubDbTask();
+});
+
+it('Should throw an error if the required args are absent.', () => {
+  const config = {
+    hapikey: null,
+    pathToContextDir: null,
+    [taskName]: {
+      batchSize: 1
+    }
+  };
+  testBase.setupMocks(config);
+  expect(() => new HubDbTask()).toThrow();
+});


### PR DESCRIPTION
Adds a new command `yarn hs-cms-server upload`, which uses the specified files in `cli-config.yaml` and uploads them to the corresponding location in the design manager.

I decided to make this its own command, rather than `yarn hs-cms-server run-tasks ftp-upload` because it seemed weird to allow this being run simultaneously with the download tasks. However, it still inherits from the `BaseTask` class since that does arg parsing/validation from `cli-config.yaml`. Let me know what you think